### PR TITLE
63 cofig parser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 test
 *.pyc
 cxxtest
+*.tst

--- a/Makefile
+++ b/Makefile
@@ -52,45 +52,6 @@ RESPONSE_GENERATOR_SRCS = $(addprefix $(SOURCE_F)/$(RESPONSE_GENERATOR_F)/,$(RES
 
 # ------------------------------------------------------------
 
-APP_CONFIG_F = configuration
-APP_CONFIG_SRC_NAMES = \
-	AppConfig.cpp \
-	Endpoint.cpp \
-	RouteConfig.cpp \
-	RouteConfig.cpp \
-	FolderConfig.cpp \
-	CgiHandlerConfig.cpp \
-	UploadConfig.cpp \
-
-
-APP_CONFIG_SRCS = $(addprefix $(SOURCE_F)/$(APP_CONFIG_F)/,$(APP_CONFIG_SRC_NAMES))
-
-# ------------------------------------------------------------
-
-LISTENER_F = listener
-LISTENER_SRC_NAMES = Listener.cpp MasterListener.cpp
-LISTENER_SRCS = $(addprefix $(SOURCE_F)/$(LISTENER_F)/,$(LISTENER_SRC_NAMES))
-
-# ------------------------------------------------------------
-
-CONNECTION_F = connection
-CONNECTION_SRC_NAMES = Connection.cpp
-CONNECTION_SRCS = $(addprefix $(SOURCE_F)/$(CONNECTION_F)/,$(CONNECTION_SRC_NAMES))
-
-# ------------------------------------------------------------
-
-REQUEST_HANDLER_F = request_handler
-REQUEST_HANDLER_SRC_NAMES = RequestHandler.cpp GetHandler.cpp
-REQUEST_HANDLER_SRCS = $(addprefix $(SOURCE_F)/$(REQUEST_HANDLER_F)/,$(REQUEST_HANDLER_SRC_NAMES))
-
-# ------------------------------------------------------------
-
-RESPONSE_GENERATOR_F = response_generator
-RESPONSE_GENERATOR_SRC_NAMES = response_generator.cpp
-RESPONSE_GENERATOR_SRCS = $(addprefix $(SOURCE_F)/$(RESPONSE_GENERATOR_F)/,$(RESPONSE_GENERATOR_SRC_NAMES))
-
-# ------------------------------------------------------------
-
 HTTP_METHODS_F = http_methods
 HTTP_METHODS_SRC_NAMES =
 HTTP_METHODS_SRCS = $(addprefix $(SOURCE_F)/$(HTTP_METHODS_F)/,$(HTTP_METHODS_SRC_NAMES))
@@ -181,14 +142,18 @@ TEST_EXECUTABLE=test
 install-cxxtest:
 	@if [ ! -d "$(CXXTEST_F)" ]; then \
 		mkdir -p $(CXXTEST_F); \
-		wget -O "$(CXXTEST_ZIP)" https://github.com/CxxTest/cxxtest/archive/refs/heads/master.zip; \
+		wget -qO "$(CXXTEST_ZIP)" https://github.com/CxxTest/cxxtest/archive/refs/heads/master.zip; \
 		unzip -qq "$(CXXTEST_ZIP)" -d "$(CXXTEST_F)"; \
 		mv $(CXXTEST_F)/cxxtest-master/* $(CXXTEST_F); \
 		rm -rf $(CXXTEST_F)/cxxtest-master $(CXXTEST_F)/master.zip;\
 	fi
 
+TEST_HEADERS := $(shell find tests -name "*.hpp")
+
 generate-cxxtest-tests: | $(OBJ_F)
-	@python3 $(CXXTEST_F)/bin/cxxtestgen --error-printer -o $(OBJ_F)/cxx_runner.cpp `find tests -name "*.hpp"`
+	@echo "Generating tests from $(TEST_HEADERS)"
+# syntax warnings come from internal cxxtest generator code problems, hiding
+	@PYTHONWARNINGS="ignore::SyntaxWarning" python3 $(CXXTEST_F)/bin/cxxtestgen --error-printer -o $(OBJ_F)/cxx_runner.cpp $(TEST_HEADERS)
 
 build-cxxtest-tests: $(MAIN_NONENDPOINT_OBJS)
 	@$(CPP) -std=c++98 -I$(CXXTEST_F) $(LINK_FLAGS) -o $(TEST_EXECUTABLE) $(OBJ_F)/cxx_runner.cpp $^

--- a/linters/cppcheck.sh
+++ b/linters/cppcheck.sh
@@ -47,8 +47,8 @@ check() {
 
 	if [ -s "$out.filtered" ]; then
 		echo "cppcheck found issues:"
-		echo "$out.filtered"
-		rm -f "$out" "$out.filtered"
+		cat "$out.filtered"
+		rm -f "$out" "$out.filtered" 
 		echo "-------------------------------------------------"
 		exit 1
 	else

--- a/linters/external_calls.sh
+++ b/linters/external_calls.sh
@@ -20,9 +20,9 @@ ALLOWED_EXTERNAL_FUNCTIONS=(
 	_GLOBAL_OFFSET_TABLE_ __gxx_personality_v0 __stack_chk_fail _stack_chk_guard
 	_Unwind_Resume 
 
-	# memmove and strlen leak from STL optimizations,
+	# memmove, memcmp, strlen leak from STL optimizations,
 	# so we allow them here, but better chek raw sources to forbid direct usage
-	memmove strlen
+	memmove strlen memcmp
 )
 
 allowed_regex="$(printf "%s\n" "${ALLOWED_EXTERNAL_FUNCTIONS[@]}" | paste -sd'|' -)"

--- a/linters/source_checker.py
+++ b/linters/source_checker.py
@@ -50,6 +50,7 @@ for f in files:
     if regexpPoll.search(s):
         pollCalls += 1
 
+	# analyzing namespaces and classes unless it's main()
     if f.name != "webserv.cpp":
         issues += checkAST(f)
 

--- a/sources/WebServer.cpp
+++ b/sources/WebServer.cpp
@@ -3,10 +3,11 @@
 #include <csignal>
 #include <cstddef>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
-#include "./configuration/AppConfig.hpp"
-#include "./listener/MasterListener.hpp"
+#include "configuration/AppConfig.hpp"
+#include "listener/MasterListener.hpp"
 
 using std::cerr;
 using std::endl;
@@ -18,7 +19,7 @@ WebServer& WebServer::operator=(const WebServer& other) {
         return (*this);
     }
     cerr << "Unexpected stub assignment operator called for WebServer." << endl;
-    _appConfig = other.getAppConfig();
+    _appConfig = new AppConfig(other.getAppConfig());
     _isRunning = 0;
     _masterListener = NULL;
     return (*this);
@@ -34,8 +35,11 @@ void WebServer::handleSignals() {
     signal(SIGINT, handleSigint);
 }
 
-AppConfig* WebServer::getAppConfig() const {
-    return (_appConfig);
+AppConfig WebServer::getAppConfig() const {
+    if (_appConfig == NULL) {
+        throw std::runtime_error("Configuration uninitialized");
+    }
+    return (*_appConfig);
 }
 
 WebServer::WebServer(const std::string& configFilePath)

--- a/sources/WebServer.hpp
+++ b/sources/WebServer.hpp
@@ -20,8 +20,6 @@ private:
 
     static void handleSignals();
 
-    AppConfig* getAppConfig() const;
-
 public:
     /* NOTE: we're not allowed to use sigaction function, only signal.
 	* signal requires a static handler,
@@ -31,6 +29,8 @@ public:
 	*/
     static WebServer& getInstance(const std::string& configFilePath);
     ~WebServer();
+
+    AppConfig getAppConfig() const;
 
     void start();
     void stop();

--- a/sources/configuration/AppConfig.cpp
+++ b/sources/configuration/AppConfig.cpp
@@ -2,12 +2,13 @@
 
 #include <set>
 #include <string>
-#include <vector>
+#include <utility>
+
+#include "RouteConfig.hpp"
 
 using std::pair;
 using std::set;
 using std::string;
-using std::vector;
 
 namespace webserver {
 
@@ -15,19 +16,42 @@ const int AppConfig::DEFAULT_MAX_BODY_SIZE = 1048576;
 
 AppConfig::AppConfig()
     : _maxRequestBodySizeBytes(DEFAULT_MAX_BODY_SIZE) {
-    _endpoints.push_back(Endpoint());
+    _endpoints.insert(Endpoint());
 }
 
-AppConfig::~AppConfig() {
+AppConfig::AppConfig(const AppConfig& other)
+    : _endpoints(other._endpoints)
+    , _maxRequestBodySizeBytes(other._maxRequestBodySizeBytes)
+    , _routes(other._routes) {
+}
+
+AppConfig& AppConfig::addEndpoint(const Endpoint& tgt) {
+    _endpoints.insert(Endpoint(tgt));
+    return (*this);
+}
+
+AppConfig& AppConfig::addRoute(std::string route, const RouteConfig& tgt) {
+    _routes.insert(std::make_pair(route, RouteConfig(tgt)));
+    return (*this);
+}
+
+bool AppConfig::operator==(const AppConfig& other) const {
+    return (
+        _endpoints == other._endpoints &&
+        _maxRequestBodySizeBytes == other._maxRequestBodySizeBytes && _routes == other._routes
+    );
 }
 
 set<pair<string, int> > AppConfig::getAllInterfacePortPairs(void) const {
     set<pair<string, int> > result;
 
-    for (vector<Endpoint>::const_iterator it = _endpoints.begin(); it != _endpoints.end(); it++) {
+    for (set<Endpoint>::const_iterator it = _endpoints.begin(); it != _endpoints.end(); it++) {
         result.insert(pair<string, int>(it->getInterface(), it->getPort()));
     }
     return (result);
+}
+
+AppConfig::~AppConfig() {
 }
 
 }  // namespace webserver

--- a/sources/configuration/AppConfig.hpp
+++ b/sources/configuration/AppConfig.hpp
@@ -3,7 +3,6 @@
 
 #include <set>
 #include <string>
-#include <vector>
 
 #include "Endpoint.hpp"
 #include "RouteConfig.hpp"
@@ -13,18 +12,22 @@ class AppConfig {
 private:
     static const int DEFAULT_MAX_BODY_SIZE;
 
-    AppConfig(const AppConfig& other);
     AppConfig& operator=(const AppConfig& other);
 
-    std::vector<Endpoint> _endpoints;
+    std::set<Endpoint> _endpoints;
     int _maxRequestBodySizeBytes;
-    std::vector<RouteConfig> _routes;
+    std::map<std::string, RouteConfig> _routes;  // NOTE: route as key (e.g. /)
 
 public:
     AppConfig();
+    AppConfig(const AppConfig& other);
     ~AppConfig();
 
     std::set<std::pair<std::string, int> > getAllInterfacePortPairs(void) const;
+    AppConfig& addEndpoint(const Endpoint& tgt);
+    AppConfig& addRoute(std::string route, const RouteConfig& tgt);
+
+    bool operator==(const AppConfig& other) const;
 };
 }  // namespace webserver
 

--- a/sources/configuration/CgiHandlerConfig.cpp
+++ b/sources/configuration/CgiHandlerConfig.cpp
@@ -1,6 +1,19 @@
 #include "CgiHandlerConfig.hpp"
 
 namespace webserver {
+CgiHandlerConfig::CgiHandlerConfig(const CgiHandlerConfig& other)
+    : _executablePath(other._executablePath)
+    , _rootPath(other._rootPath)
+    , _timeoutSeconds(other._timeoutSeconds) {
+}
+
+bool CgiHandlerConfig::operator==(const CgiHandlerConfig& other) const {
+    return (
+        _executablePath == other._executablePath && _rootPath == other._rootPath &&
+        _timeoutSeconds == other._timeoutSeconds
+    );
+}
+
 CgiHandlerConfig::~CgiHandlerConfig() {
 }
 }  // namespace webserver

--- a/sources/configuration/CgiHandlerConfig.hpp
+++ b/sources/configuration/CgiHandlerConfig.hpp
@@ -1,13 +1,13 @@
 #ifndef CGIHANDLER_HPP
 #define CGIHANDLER_HPP
 
+#include <set>
 #include <string>
 
 namespace webserver {
 class CgiHandlerConfig {
 private:
     CgiHandlerConfig();
-    CgiHandlerConfig(const CgiHandlerConfig& other);
     CgiHandlerConfig& operator=(const CgiHandlerConfig& other);
 
     std::string _executablePath;
@@ -21,7 +21,10 @@ public:
         bool enableListing,
         const std::string& indexPageFileLocation
     );
+    CgiHandlerConfig(const CgiHandlerConfig& other);
     ~CgiHandlerConfig();
+
+    bool operator==(const CgiHandlerConfig& other) const;
 };
 }  // namespace webserver
 

--- a/sources/configuration/Endpoint.cpp
+++ b/sources/configuration/Endpoint.cpp
@@ -28,9 +28,6 @@ Endpoint& Endpoint::operator=(const Endpoint& other) {
     return (*this);
 }
 
-Endpoint::~Endpoint() {
-}
-
 int Endpoint::getPort(void) const {
     return (_port);
 }
@@ -39,4 +36,17 @@ string Endpoint::getInterface(void) const {
     return (_interface);
 }
 
+bool Endpoint::operator<(const Endpoint& other) const {
+    if (_interface != other._interface) {
+        return (_interface < other._interface);
+    }
+    return (_port < other._port);
+}
+
+bool Endpoint::operator==(const Endpoint& other) const {
+    return (_interface == other._interface && _port == other._port);
+}
+
+Endpoint::~Endpoint() {
+}
 }  // namespace webserver

--- a/sources/configuration/Endpoint.hpp
+++ b/sources/configuration/Endpoint.hpp
@@ -17,6 +17,8 @@ public:
     Endpoint(const std::string& interface, int port);
     Endpoint(const Endpoint& other);
     Endpoint& operator=(const Endpoint& other);
+    bool operator<(const Endpoint& other) const;
+    bool operator==(const Endpoint& other) const;
     ~Endpoint();
 
     int getPort(void) const;

--- a/sources/configuration/FolderConfig.cpp
+++ b/sources/configuration/FolderConfig.cpp
@@ -1,6 +1,31 @@
 #include "FolderConfig.hpp"
 
+#include <string>
+
 namespace webserver {
+FolderConfig::FolderConfig(
+    const std::string& rootPath,
+    bool enableListing,
+    const std::string& indexPageFileLocation
+)
+    : _rootPath(rootPath)
+    , _enableListing(enableListing)
+    , _indexPageFileLocation(indexPageFileLocation) {
+}
+
+FolderConfig::FolderConfig(const FolderConfig& other)
+    : _rootPath(other._rootPath)
+    , _enableListing(other._enableListing)
+    , _indexPageFileLocation(other._indexPageFileLocation) {
+}
+
+bool FolderConfig::operator==(const FolderConfig& other) const {
+    return (
+        _rootPath == other._rootPath && _enableListing == other._enableListing &&
+        _indexPageFileLocation == other._indexPageFileLocation
+    );
+}
+
 FolderConfig::~FolderConfig() {
 }
 }  // namespace webserver

--- a/sources/configuration/FolderConfig.hpp
+++ b/sources/configuration/FolderConfig.hpp
@@ -7,19 +7,20 @@ namespace webserver {
 class FolderConfig {
 private:
     FolderConfig();
-    FolderConfig(const FolderConfig& other);
-    FolderConfig& operator=(const FolderConfig& other);
 
     std::string _rootPath;
     bool _enableListing;  // TODO 15: default false
     std::string _indexPageFileLocation;
 
 public:
+    FolderConfig(const FolderConfig& other);
+    FolderConfig& operator=(const FolderConfig& other);
     FolderConfig(
         const std::string& rootPath,
         bool enableListing,
         const std::string& indexPageFileLocation
     );
+    bool operator==(const FolderConfig& other) const;
     ~FolderConfig();
 };
 }  // namespace webserver

--- a/sources/configuration/RouteConfig.cpp
+++ b/sources/configuration/RouteConfig.cpp
@@ -1,6 +1,50 @@
 #include "RouteConfig.hpp"
 
+#include <cstddef>
+
+#include "FolderConfig.hpp"
+#include "UploadConfig.hpp"
+
 namespace webserver {
+RouteConfig::RouteConfig()
+    : _folderConfigSection(NULL)
+    , _uploadConfigSection(NULL) {
+}
+
+RouteConfig::RouteConfig(const RouteConfig& other)
+    : _allowedMethods(other._allowedMethods)
+    , _redirections(other._redirections)
+    , _folderConfigSection(other._folderConfigSection)
+    , _uploadConfigSection(other._uploadConfigSection)
+    , _cgiHandlers(other._cgiHandlers) {
+}
+
+RouteConfig& RouteConfig::operator=(const RouteConfig& other) {
+    if (&other == this) {
+        return (*this);
+    }
+    _allowedMethods = other._allowedMethods;
+    _redirections = other._redirections;
+    _folderConfigSection = new FolderConfig(*other._folderConfigSection);
+    _uploadConfigSection = new UploadConfig(*other._uploadConfigSection);
+    _cgiHandlers = other._cgiHandlers;
+    return (*this);
+}
+
+RouteConfig& RouteConfig::setFolderConfig(const FolderConfig& tgt) {
+    _folderConfigSection = new FolderConfig(tgt);
+    return (*this);
+}
+
+bool RouteConfig::operator==(const RouteConfig& other) const {
+    return (
+        _allowedMethods == other._allowedMethods && _redirections == other._redirections &&
+        (*_folderConfigSection) == (*(other._folderConfigSection)) &&
+        (*_uploadConfigSection) == (*(other._uploadConfigSection)) &&
+        _cgiHandlers == other._cgiHandlers
+    );
+}
+
 RouteConfig::~RouteConfig() {
 }
 }  // namespace webserver

--- a/sources/configuration/RouteConfig.hpp
+++ b/sources/configuration/RouteConfig.hpp
@@ -3,6 +3,7 @@
 #define ROUTE_HPP
 
 #include <map>
+#include <set>
 #include <vector>
 
 #include "../http_methods/HttpMethodType.hpp"
@@ -13,10 +14,7 @@
 namespace webserver {
 class RouteConfig {
 private:
-    RouteConfig(const RouteConfig& other);
-    RouteConfig& operator=(const RouteConfig& other);
-
-    std::vector<HttpMethodType> _allowedMethods;
+    std::set<HttpMethodType> _allowedMethods;
     std::map<std::string, std::string> _redirections;  // NOTE: from:to
     FolderConfig* _folderConfigSection;
     UploadConfig* _uploadConfigSection;
@@ -24,6 +22,12 @@ private:
 
 public:
     RouteConfig();
+    RouteConfig& operator=(const RouteConfig& other);
+    RouteConfig(const RouteConfig& other);
+
+    RouteConfig& setFolderConfig(const FolderConfig& tgt);
+
+    bool operator==(const RouteConfig& other) const;
     ~RouteConfig();
 };
 }  // namespace webserver

--- a/sources/configuration/UploadConfig.cpp
+++ b/sources/configuration/UploadConfig.cpp
@@ -1,6 +1,15 @@
 #include "UploadConfig.hpp"
 
 namespace webserver {
+UploadConfig::UploadConfig(const UploadConfig& other)
+    : _uploadEnabled(other._uploadEnabled)
+    , _uploadRootFolder(other._uploadRootFolder) {
+}
+
+bool UploadConfig::operator==(const UploadConfig& other) const {
+    return (_uploadEnabled == other._uploadEnabled && _uploadRootFolder == other._uploadRootFolder);
+}
+
 UploadConfig::~UploadConfig() {
 }
 }  // namespace webserver

--- a/sources/configuration/UploadConfig.hpp
+++ b/sources/configuration/UploadConfig.hpp
@@ -7,15 +7,17 @@ namespace webserver {
 class UploadConfig {
 private:
     UploadConfig();
-    UploadConfig(const UploadConfig& other);
-    UploadConfig& operator=(const UploadConfig& other);
 
     bool _uploadEnabled;  // TODO 15: default false
     const std::string _uploadRootFolder;
 
 public:
     UploadConfig(bool uploadEnabled, const std::string& uploadRootFolder);
+    UploadConfig(const UploadConfig& other);
+    UploadConfig& operator=(const UploadConfig& other);
     ~UploadConfig();
+
+    bool operator==(const UploadConfig& other) const;
 };
 }  // namespace webserver
 

--- a/tests/unit/ConfigParsingTests.hpp
+++ b/tests/unit/ConfigParsingTests.hpp
@@ -1,0 +1,61 @@
+#ifndef CONFIGPARSINGTESTS_HPP
+#define CONFIGPARSINGTESTS_HPP
+
+#include <cxxtest/TestSuite.h>
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "WebServer.hpp"
+
+using std::endl;
+using std::ofstream;
+using std::set;
+using std::string;
+
+class ConfigParsingTests : public CxxTest::TestSuite {
+private:
+    set<string> _configFilenames;
+
+public:
+    void testConfig0() {
+        const string fname = "config0.tst";
+        _configFilenames.insert(fname);
+        ofstream f("config0.tst");
+        f << "server {\n"
+          << "\tlisten 8080;\n"
+          << "\tserver_name localhost;\n"
+          << "\tlocation / {\n"
+          << "\t\troot /var/www/html;\n"
+          << "\t\tindex index.html;\n"
+          << "\t}\n"
+          << "}" << endl;
+        f.close();
+        // TODO 15: probably should call the parser class, not instantiate the server, since it adds extra log output to the logs
+        webserver::WebServer& s = webserver::WebServer::getInstance(fname);
+
+        webserver::AppConfig expected;
+        expected.addEndpoint(webserver::Endpoint("localhost", 8080))
+            .addRoute(
+                "/",
+                webserver::RouteConfig().setFolderConfig(
+                    webserver::FolderConfig("/", false, "index.html")
+                )
+            );
+        TS_SKIP("configuration parsing not implemented");
+        TS_ASSERT_THROWS_NOTHING(s.getAppConfig());
+        TS_ASSERT_EQUALS(expected, s.getAppConfig());
+    }
+
+    void tearDown() {
+        for (set<string>::iterator it = _configFilenames.begin(); it != _configFilenames.end();
+             it++) {
+            if (std::remove(it->c_str()) != 0) {
+                std::cerr << "Failed to remove file " << it->c_str() << "\n";
+            }
+        }
+    }
+};
+#endif


### PR DESCRIPTION
Target change:
- added a functional CxxTest suite to validate future configuration parsing result: an AppConfig is being created through default WebServer constructor, then a sample AppConfig is being created manually with expected values, then they are asserted to be the same. The test is disabled for now, as the parsing is not implemented.
- multiple getters/setters/copy/assignment/constructors/comparators made public and implemented to make tests compile
- changed storage structure: 
  - RouteConfig stores allowed methods not as a vector rather as a set (order doesn't make sense, but uniqueness does)
  - AppConfig stores Endpoints as a set, not a vector (same) and routes as a map <route to its config>

Verification:
- `make test`, see logs about a skipped test
- can try reenabling it by removing TS_SKIP, but then it fails, as WebServer.getAppConfig currently throws an exception (the pointer object hasn't been created yet)
- the configuration file generated during the test should have been deleted by the test automatically (no config0.tst in root folder)