### PR TITLE
53 storing client IP and port when accepting new connections

### DIFF
--- a/sources/connection/Connection.hpp
+++ b/sources/connection/Connection.hpp
@@ -2,6 +2,7 @@
 #define CONNECTION_HPP
 
 #include <poll.h>
+#include <stdint.h>
 
 #include <map>
 #include <string>
@@ -16,6 +17,8 @@ private:
     int _clientSocketFd;
     std::string _responseBuffer;
     Request* _request;
+    uint32_t _clientIp;
+    uint16_t _clientPort;
 
     Connection(const Connection& other);
     Connection& operator=(const Connection& other);


### PR DESCRIPTION
- Store client IPv4 address and port when accepting new connections in Connection class.
- Log accepted connection in the format: "Accepted connection from <IP>:<port>".
- No functional behavior changes; only data storage and logging.
- Fully C++98 compliant and uses only allowed functions.
- IP stored in network byte order; port stored in host byte order.

Verification 

- Start the web server locally
- Connect with a client (curl or browser):
- Observe logs in the console:
Accepted connection from 127.0.0.1:<ephemeral_port>

Expected behavior:
The IP corresponds to the client machine (127.0.0.1 for local tests).
Port is a valid ephemeral port assigned by the OS.
No requests fail; server functionality is unchanged.