### PR TITLE
137 signal handler should not stop webserver directly use sigint flag

### DIFF
--- a/sources/WebServer.hpp
+++ b/sources/WebServer.hpp
@@ -14,6 +14,7 @@ private:
     // NOTE: DL: __sig_atomic_t is a special int type guaranteed to be writable in one atomic CPU operation & safe to modify inside a signal handler
     // NOTE: DL: volatile tells the compiler: “Don’t optimize access to this variable. Always read/write it directly from memory.”
     volatile __sig_atomic_t _isRunning;
+
     MasterListener _masterListener;
     static Logger _log;
 
@@ -26,6 +27,12 @@ private:
     static void handleSignals();
 
 public:
+    /* NOTE: Flag used for communication with signal handlers.
+    * sig_atomic_t guarantees that reads/writes are not interrupted,
+    * and static storage duration makes it safe to access from a signal handler.
+    */
+    static volatile __sig_atomic_t serverSignals;
+
     ~WebServer();
 
     /* NOTE: we're not allowed to use sigaction function, only signal.

--- a/sources/listener/MasterListener.hpp
+++ b/sources/listener/MasterListener.hpp
@@ -1,4 +1,3 @@
-#pragma once
 #ifndef MASTERLISTENER_HPP
 #define MASTERLISTENER_HPP
 
@@ -15,7 +14,6 @@ namespace webserver {
 class MasterListener {
 private:
     static Logger _log;
-    MasterListener(const MasterListener& other);
 
     std::vector<struct ::pollfd> _pollFds;
     /* NOTE:
@@ -33,6 +31,8 @@ private:
     std::map<int, int> _responseWorkers;
     // NOTE: reading pipe end fd with an expected generated response: client socket fd
 
+    MasterListener(const MasterListener& other);
+
     int registerNewConnection(int listeningFd, Listener* listener);
     void removePollFd(int fdesc);
     void populateFdsFromListeners();
@@ -46,14 +46,17 @@ private:
     Connection::State isItAResponseFromAResponseGeneratorWorker(::pollfd& activeFd);
     Connection::State handleIncomingConnection(::pollfd& activeFd, bool& acceptingNewConnections);
     void handleOutgoingConnection(const ::pollfd& activeFd);
+    void resetPollEvents();
+    void handlePollEvents(bool& acceptingNewConnections);
     static void reapChildren();
 
 public:
     MasterListener();
     explicit MasterListener(const AppConfig& configuration);
     MasterListener& operator=(const MasterListener& other);
-    void listenAndHandle(volatile __sig_atomic_t& isRunning);
     ~MasterListener();
+
+    void listenAndHandle(volatile __sig_atomic_t& isRunning, volatile __sig_atomic_t& signals);
 };
 }  // namespace webserver
 #endif

--- a/sources/signals/ServerSignal.hpp
+++ b/sources/signals/ServerSignal.hpp
@@ -1,0 +1,20 @@
+#ifndef SERVERSIGNAL_HPP
+#define SERVERSIGNAL_HPP
+
+#include <signal.h>
+
+#include <csignal>
+
+namespace webserver {
+
+enum ServerSignal {
+    SIG_NONE = 0,
+    SIG_SHUTDOWN = 1 << 0,
+    SIG_RELOAD = 1 << 1,
+    SIG_PAUSE = 1 << 2,
+    SIG_RESUME = 1 << 3
+};
+
+}  // namespace webserver
+
+#endif


### PR DESCRIPTION
**Summary**
This PR reworks the signal handling logic to make it signal-safe.
The previous implementation performed non–signal-safe operations directly inside signal handlers.
The new implementation ensures that signal handlers only set flags, and all actual logic is processed later inside the main event loop.

**What was changed**
Introduced a bitmask-based signal flag (ServerSignal) to represent signal intent

**Signal handlers now:**
- perform no logic
- only set atomic flags

Signal processing is deferred to the main loop (listenAndHandle).

**Added support for graceful handling of:**
Ctrl+C (SIGINT)
Ctrl+Z (SIGTSTP) – essentially solving #133 
Graceful termination via kill / kill -15 (SIGTERM)

**Ensured shutdown is graceful:**
1. stop accepting new connections
2. finish existing ones
3. exit cleanly when safe